### PR TITLE
Remove congratulation message for extension activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,11 +6,6 @@ import TabConverter from './tabConverter';
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: ExtensionContext) {
-
-    // Use the console to output diagnostic information (console.log) and errors (console.error)
-    // This line of code will only be executed once when your extension is activated
-    console.log('Congratulations, your extension "TabConverter" is now active!'); 
-    
     // The command has been defined in the package.json file
     // Now provide the implementation of the command with  registerCommand
     // The commandId parameter must match the command field in package.json


### PR DESCRIPTION
As its only purpose was to confirm that the project was correctly generated by Yeoman.

Also, thanks for the useful extension :+1: 

> **Note**: You can directly accept this PR with instructions in #3.
